### PR TITLE
Put 4844 rules in serenity consensus engine

### DIFF
--- a/consensus/serenity/serenity.go
+++ b/consensus/serenity/serenity.go
@@ -129,6 +129,13 @@ func (s *Serenity) Finalize(config *params.ChainConfig, header *types.Header, st
 	for _, w := range withdrawals {
 		state.AddBalance(w.Address, &w.Amount)
 	}
+	if config.IsSharding(header.Number.Uint64()) {
+		parent := chain.GetHeaderByHash(header.ParentHash)
+		if parent == nil {
+			return nil, nil, fmt.Errorf("Could not find the parent of block %v to get excess data gas", header.Number.Uint64())
+		}
+		header.SetExcessDataGas(misc.CalcExcessDataGas(parent.ExcessDataGas, misc.CountBlobs(txs)))
+	}
 	return txs, r, nil
 }
 
@@ -210,6 +217,15 @@ func (s *Serenity) verifyHeader(chain consensus.ChainHeaderReader, header, paren
 	}
 	if !shanghai && header.WithdrawalsHash != nil {
 		return consensus.ErrUnexpectedWithdrawals
+	}
+
+	if !chain.Config().IsSharding(header.Number.Uint64()) {
+		if header.ExcessDataGas != nil {
+			return fmt.Errorf("invalid excessDataGas before fork: have %v, expected 'nil'", header.ExcessDataGas)
+		}
+	} else if err := misc.VerifyEip4844Header(chain.Config(), parent, header); err != nil {
+		// Verify the header's EIP-4844 attributes.
+		return err
 	}
 	return nil
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -516,6 +516,7 @@ func (h *Header) SetExcessDataGas(v *big.Int) {
 		h.ExcessDataGas.Set(v)
 	}
 	if h.WithdrawalsHash == nil {
+		fmt.Println("Setting withdrawals hash to empty root hash")
 		// leaving this nil would result in a buggy encoding
 		h.WithdrawalsHash = &EmptyRootHash
 	}
@@ -785,6 +786,7 @@ func (rb *RawBody) DecodeRLP(s *rlp.Stream) error {
 		}
 		return fmt.Errorf("read Withdrawals: %w", err)
 	}
+	rb.Withdrawals = []*Withdrawal{} // withdrawals should never be nil post-Capella
 	for err == nil {
 		var withdrawal Withdrawal
 		if err = withdrawal.DecodeRLP(s); err != nil {
@@ -1148,6 +1150,7 @@ func (bb *Block) DecodeRLP(s *rlp.Stream) error {
 		}
 		return fmt.Errorf("read Withdrawals: %w", err)
 	}
+	bb.withdrawals = []*Withdrawal{} // withdrawals should never be nil post-Capella
 	for err == nil {
 		var withdrawal Withdrawal
 		if err = withdrawal.DecodeRLP(s); err != nil {

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -425,4 +425,70 @@ func TestWithdrawalsEncoding(t *testing.T) {
 	require.NoError(t, rlp.DecodeBytes(encoded, &decoded))
 
 	assert.Equal(t, block, &decoded)
+
+	// Now test with empty withdrawals
+	block2 := NewBlock(&header, nil, nil, nil, []*Withdrawal{})
+	_ = block2.Size()
+
+	encoded2, err := rlp.EncodeToBytes(block2)
+	require.NoError(t, err)
+
+	var decoded2 Block
+	require.NoError(t, rlp.DecodeBytes(encoded2, &decoded2))
+
+	assert.Equal(t, block2, &decoded2)
+}
+
+func TestExcessDataGasEncoding(t *testing.T) {
+	header := Header{
+		ParentHash:    common.HexToHash("0x8b00fcf1e541d371a3a1b79cc999a85cc3db5ee5637b5159646e1acd3613fd15"),
+		Coinbase:      common.HexToAddress("0x571846e42308df2dad8ed792f44a8bfddf0acb4d"),
+		Root:          common.HexToHash("0x351780124dae86b84998c6d4fe9a88acfb41b4856b4f2c56767b51a4e2f94dd4"),
+		Difficulty:    common.Big0,
+		Number:        big.NewInt(20_000_000),
+		GasLimit:      30_000_000,
+		GasUsed:       3_074_345,
+		Time:          1666343339,
+		Extra:         make([]byte, 0),
+		MixDigest:     common.HexToHash("0x7f04e338b206ef863a1fad30e082bbb61571c74e135df8d1677e3f8b8171a09b"),
+		BaseFee:       big.NewInt(7_000_000_000),
+		ExcessDataGas: big.NewInt(8_000_000),
+	}
+
+	withdrawals := make([]*Withdrawal, 2)
+	withdrawals[0] = &Withdrawal{
+		Index:     44555666,
+		Validator: 89,
+		Address:   common.HexToAddress("0x690b9a9e9aa1c9db991c7721a92d351db4fac990"),
+		Amount:    *uint256.NewInt(2 * params.Ether),
+	}
+	withdrawals[1] = &Withdrawal{
+		Index:     44555667,
+		Validator: 37,
+		Address:   common.HexToAddress("0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5"),
+		Amount:    *uint256.NewInt(5 * params.Ether),
+	}
+
+	block := NewBlock(&header, nil, nil, nil, withdrawals)
+	_ = block.Size()
+
+	encoded, err := rlp.EncodeToBytes(block)
+	require.NoError(t, err)
+
+	var decoded Block
+	require.NoError(t, rlp.DecodeBytes(encoded, &decoded))
+
+	assert.Equal(t, block, &decoded)
+
+	// Now test with empty withdrawals
+	block2 := NewBlock(&header, nil, nil, nil, []*Withdrawal{})
+	_ = block2.Size()
+
+	encoded2, err := rlp.EncodeToBytes(block2)
+	require.NoError(t, err)
+
+	var decoded2 Block
+	require.NoError(t, rlp.DecodeBytes(encoded2, &decoded2))
+
+	assert.Equal(t, block2, &decoded2)
 }

--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,8 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pelletier/go-toml/v2 v2.0.6
 	github.com/pion/stun v0.3.5
-	github.com/protolambda/ztyp v0.2.2
 	github.com/pkg/errors v0.9.1
+	github.com/protolambda/ztyp v0.2.2
 	github.com/prysmaticlabs/fastssz v0.0.0-20220628121656-93dfe28febab
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
 	github.com/prysmaticlabs/gohashtree v0.0.0-20220517220438-192ee5ae6982
@@ -144,16 +144,16 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
-	github.com/herumi/bls-eth-go-binary v1.28.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/herumi/bls-eth-go-binary v1.28.1 // indirect
 	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20220405231054-a1ae3e4bba26 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/ipfs/go-cid v0.3.2 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
-	github.com/kilic/bls12-381 v0.1.1-0.20220929213557-ca162e8a70f4 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/kilic/bls12-381 v0.1.1-0.20220929213557-ca162e8a70f4 // indirect
 	github.com/klauspost/compress v1.15.10 // indirect
 	github.com/klauspost/cpuid/v2 v2.1.1 // indirect
 	github.com/koron/go-ssdp v0.0.3 // indirect
@@ -219,52 +219,6 @@ require (
 )
 
 require (
-	crawshaw.io/sqlite v0.3.3-0.20210127221821-98b1f83c5508 // indirect
-	github.com/ajwerner/btree v0.0.0-20211221152037-f427b3e689c0 // indirect
-	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
-	github.com/anacrolix/chansync v0.3.0 // indirect
-	github.com/anacrolix/dht/v2 v2.19.0 // indirect
-	github.com/anacrolix/envpprof v1.2.1 // indirect
-	github.com/anacrolix/generics v0.0.0-20220618083756-f99e35403a60 // indirect
-	github.com/anacrolix/missinggo v1.3.0 // indirect
-	github.com/anacrolix/missinggo/perf v1.0.0 // indirect
-	github.com/anacrolix/missinggo/v2 v2.7.0 // indirect
-	github.com/anacrolix/mmsg v1.0.0 // indirect
-	github.com/anacrolix/multiless v0.3.0 // indirect
-	github.com/anacrolix/stm v0.4.0 // indirect
-	github.com/anacrolix/upnp v0.1.3-0.20220123035249-922794e51c96 // indirect
-	github.com/anacrolix/utp v0.1.0 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/benbjohnson/immutable v0.3.0 // indirect
-	github.com/bits-and-blooms/bitset v1.2.2 // indirect
-	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
-	github.com/docker/docker v20.10.17+incompatible
-	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/fsnotify/fsnotify v1.5.4 // indirect
-	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
-	github.com/go-kit/kit v0.10.0 // indirect
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
-	github.com/go-stack/stack v1.8.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
-	github.com/huandu/xstrings v1.3.2
-	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20220405231054-a1ae3e4bba26 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/lispad/go-generics-tools v1.1.0 // indirect
-	github.com/magiconair/properties v1.8.6 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.16 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/pion/datachannel v1.5.2 // indirect
 	github.com/pion/dtls/v2 v2.1.5 // indirect
 	github.com/pion/ice/v2 v2.2.6 // indirect
@@ -282,26 +236,14 @@ require (
 	github.com/pion/udp v0.1.1 // indirect
 	github.com/pion/webrtc/v3 v3.1.42 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.13.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.37.0 // indirect
-	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/supranational/blst v0.3.10 // indirect
 	github.com/valyala/fastrand v1.1.0 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect
-	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
-	go.opentelemetry.io/otel v1.8.0 // indirect
-	go.opentelemetry.io/otel/trace v1.8.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/tools v0.3.0 // indirect
@@ -309,7 +251,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.3.0 // indirect
-	lukechampine.com/blake3 v1.1.7 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect
 	modernc.org/cc/v3 v3.40.0 // indirect
 	modernc.org/ccgo/v3 v3.16.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -663,6 +663,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -846,8 +847,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/protolambda/go-kzg v0.0.0-20221121235515-3f3e1ef6beb7 h1:yzqsT6UIT17bmesiG9iB6+3cQkmMAtFjUffx5KrXgkk=
-github.com/protolambda/go-kzg v0.0.0-20221121235515-3f3e1ef6beb7/go.mod h1:7EhkBJFo/qJ9sToiW5baPqbyPo/TadVHn4iNdpwEW/w=
 github.com/protolambda/go-kzg v0.0.0-20221122014024-bb3fa3695412 h1:MQBDul/k5XDDYF5fVn18lNwkWKxpK93FbYeaum1b1UE=
 github.com/protolambda/go-kzg v0.0.0-20221122014024-bb3fa3695412/go.mod h1:7EhkBJFo/qJ9sToiW5baPqbyPo/TadVHn4iNdpwEW/w=
 github.com/protolambda/ztyp v0.2.2 h1:rVcL3vBu9W/aV646zF6caLS/dyn9BN8NYiuJzicLNyY=


### PR DESCRIPTION
Also:

- make sure Withdrawals field is never nil after decoding post-capella encoded blocks & bodies (this is a bug that I should also submit upstream)

- add test for encoding/decoding of excess data gas field

- go mod tidy