### PR TITLE
decouple RLP and canonical transaction decoding so that blob txs can …

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -950,7 +950,7 @@ func scanTxs(chaindata string) error {
 			return err
 		}
 		var tr types.Transaction
-		if tr, err = types.DecodeTransaction(rlp.NewStream(bytes.NewReader(v), 0)); err != nil {
+		if tr, err = types.DecodeTransaction(v); err != nil {
 			return err
 		}
 		if _, ok := trTypes[tr.Type()]; !ok {

--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	types2 "github.com/ledgerwatch/erigon/core/types"
-	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/rpchelper"
 )
@@ -96,8 +95,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Has
 		return nil, err
 	}
 	if len(reply.RlpTxs[0]) > 0 {
-		s := rlp.NewStream(bytes.NewReader(reply.RlpTxs[0]), uint64(len(reply.RlpTxs[0])))
-		txn, err := types2.DecodeTransaction(s)
+		txn, err := types2.DecodeTransaction(reply.RlpTxs[0])
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rpcdaemon/commands/send_transaction.go
+++ b/cmd/rpcdaemon/commands/send_transaction.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -15,13 +14,12 @@ import (
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/params"
-	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/log/v3"
 )
 
 // SendRawTransaction implements eth_sendRawTransaction. Creates new message call transaction or a contract creation for previously-signed transactions.
 func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
-	txn, err := types.DecodeTransaction(rlp.NewStream(bytes.NewReader(encodedTx), uint64(len(encodedTx))))
+	txn, err := types.DecodeTransaction(encodedTx)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/cmd/rpcdaemon/commands/txpool_api.go
+++ b/cmd/rpcdaemon/commands/txpool_api.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/types"
-	"github.com/ledgerwatch/erigon/rlp"
 )
 
 // NetAPI the interface for the net_ RPC commands
@@ -52,8 +50,7 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 	baseFee := make(map[common.Address][]types.Transaction, 8)
 	queued := make(map[common.Address][]types.Transaction, 8)
 	for i := range reply.Txs {
-		stream := rlp.NewStream(bytes.NewReader(reply.Txs[i].RlpTx), 0)
-		txn, err := types.DecodeTransaction(stream)
+		txn, err := types.DecodeTransaction(reply.Txs[i].RlpTx)
 		if err != nil {
 			return nil, err
 		}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -390,7 +390,7 @@ func CanonicalTxnByID(db kv.Getter, id uint64) (types.Transaction, error) {
 	if err != nil {
 		return nil, err
 	}
-	txn, err := types.DecodeTransaction(rlp.NewStream(bytes.NewReader(v), uint64(len(v))))
+	txn, err := types.DecodeTransaction(v)
 	if err != nil {
 		return nil, err
 	}
@@ -402,17 +402,13 @@ func CanonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]type
 		return []types.Transaction{}, nil
 	}
 	txIdKey := make([]byte, 8)
-	reader := bytes.NewReader(nil)
-	stream := rlp.NewStream(reader, 0)
 	txs := make([]types.Transaction, amount)
 	binary.BigEndian.PutUint64(txIdKey, baseTxId)
 	i := uint32(0)
 
 	if err := db.ForAmount(kv.EthTx, txIdKey, amount, func(k, v []byte) error {
 		var decodeErr error
-		reader.Reset(v)
-		stream.Reset(reader, 0)
-		if txs[i], decodeErr = types.DecodeTransaction(stream); decodeErr != nil {
+		if txs[i], decodeErr = types.UnmarshalTransactionFromBinary(v); decodeErr != nil {
 			return decodeErr
 		}
 		i++
@@ -429,17 +425,13 @@ func NonCanonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]t
 		return []types.Transaction{}, nil
 	}
 	txIdKey := make([]byte, 8)
-	reader := bytes.NewReader(nil)
-	stream := rlp.NewStream(reader, 0)
 	txs := make([]types.Transaction, amount)
 	binary.BigEndian.PutUint64(txIdKey, baseTxId)
 	i := uint32(0)
 
 	if err := db.ForAmount(kv.NonCanonicalTxs, txIdKey, amount, func(k, v []byte) error {
 		var decodeErr error
-		reader.Reset(v)
-		stream.Reset(reader, 0)
-		if txs[i], decodeErr = types.DecodeTransaction(stream); decodeErr != nil {
+		if txs[i], decodeErr = types.DecodeTransaction(v); decodeErr != nil {
 			return decodeErr
 		}
 		i++

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -930,7 +930,7 @@ func (bb *Body) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx Transaction
-	for tx, err = DecodeTransaction(s); err == nil; tx, err = DecodeTransaction(s) {
+	for tx, err = DecodeRLPTransaction(s); err == nil; tx, err = DecodeRLPTransaction(s) {
 		bb.Transactions = append(bb.Transactions, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {
@@ -1113,7 +1113,7 @@ func (bb *Block) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx Transaction
-	for tx, err = DecodeTransaction(s); err == nil; tx, err = DecodeTransaction(s) {
+	for tx, err = DecodeRLPTransaction(s); err == nil; tx, err = DecodeRLPTransaction(s) {
 		bb.transactions = append(bb.transactions, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {

--- a/core/types/starknet_tx_test.go
+++ b/core/types/starknet_tx_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/params"
-	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 )
@@ -77,7 +76,7 @@ func TestStarknetTxDecodeRLP(t *testing.T) {
 
 			encodedTx := buf.Bytes()
 
-			txnObj, err := DecodeTransaction(rlp.NewStream(bytes.NewReader(encodedTx), uint64(len(encodedTx))))
+			txnObj, err := UnmarshalTransactionFromBinary(encodedTx)
 			require.NoError(err)
 
 			txn, ok := txnObj.(*StarknetTransaction)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -123,7 +123,7 @@ func (tm TransactionMisc) From() *atomic.Value {
 	return &tm.from
 }
 
-func DecodeTransaction(s *rlp.Stream) (Transaction, error) {
+func DecodeRLPTransaction(s *rlp.Stream) (Transaction, error) {
 	kind, size, err := s.Kind()
 	if err != nil {
 		return nil, err
@@ -135,58 +135,69 @@ func DecodeTransaction(s *rlp.Stream) (Transaction, error) {
 		}
 		return tx, nil
 	}
-	if rlp.String == kind {
-		s.NewList(size) // Hack - convert String (envelope) into List
+	if rlp.String != kind {
+		return nil, fmt.Errorf("Not an RLP encoded transaction. If this is a canonical encoded transaction, use UnmarshalTransactionFromBinary instead. Got %v for kind, expected String", kind)
 	}
+	// Decode the EIP-2718 typed TX envelope.
 	var b []byte
 	if b, err = s.Bytes(); err != nil {
 		return nil, err
 	}
-	if len(b) != 1 {
-		return nil, fmt.Errorf("%w, got %d bytes", rlp.ErrWrongTxTypePrefix, len(b))
+	if len(b) == 0 {
+		return nil, rlp.EOL
 	}
-	var tx Transaction
-	switch b[0] {
-	case AccessListTxType:
-		t := &AccessListTx{}
-		if err = t.DecodeRLP(s); err != nil {
-			return nil, err
-		}
-		tx = t
-	case DynamicFeeTxType:
-		t := &DynamicFeeTransaction{}
-		if err = t.DecodeRLP(s); err != nil {
-			return nil, err
-		}
-		tx = t
-	case StarknetType:
-		t := &StarknetTransaction{}
-		if err = t.DecodeRLP(s); err != nil {
-			return nil, err
-		}
-		tx = t
-	default:
-		return nil, fmt.Errorf("%w, got: %d", rlp.ErrUnknownTxTypePrefix, b[0])
+	return UnmarshalTransactionFromBinary(b)
+}
+
+// DecodeTransaction decodes a transaction either in RLP or canonical format
+func DecodeTransaction(data []byte) (Transaction, error) {
+	if len(data) == 0 {
+		return nil, io.EOF
 	}
-	if kind == rlp.String {
-		if err = s.ListEnd(); err != nil {
-			return nil, err
-		}
+	if data[0] < 0x80 {
+		// the encoding is canonical, not RLP
+		return UnmarshalTransactionFromBinary(data)
 	}
-	return tx, nil
+	s := rlp.NewStream(bytes.NewReader(data), uint64(len(data)))
+	return DecodeRLPTransaction(s)
 }
 
 func UnmarshalTransactionFromBinary(data []byte) (Transaction, error) {
-	txType := data[0]
-	if txType == BlobTxType {
-		var blobTx SignedBlobTx
-		if err := DecodeSSZ(data[1:], &blobTx); err != nil {
+	if len(data) <= 1 {
+		return nil, fmt.Errorf("short input: %v", len(data))
+	}
+	switch data[0] {
+	case BlobTxType:
+		t := &SignedBlobTx{}
+		if err := DecodeSSZ(data[1:], t); err != nil {
 			return nil, err
 		}
-		return &blobTx, nil
+		return t, nil
+	case AccessListTxType:
+		s := rlp.NewStream(bytes.NewReader(data[1:]), uint64(len(data)-1))
+		t := &AccessListTx{}
+		if err := t.DecodeRLP(s); err != nil {
+			return nil, err
+		}
+		return t, nil
+	case DynamicFeeTxType:
+		s := rlp.NewStream(bytes.NewReader(data[1:]), uint64(len(data)-1))
+		t := &DynamicFeeTransaction{}
+		if err := t.DecodeRLP(s); err != nil {
+			return nil, err
+		}
+		return t, nil
+	case StarknetType:
+		s := rlp.NewStream(bytes.NewReader(data[1:]), uint64(len(data)-1))
+		t := &StarknetTransaction{}
+		if err := t.DecodeRLP(s); err != nil {
+			return nil, err
+		}
+		return t, nil
+	default:
+		// Tx is type legacy which is RLP encoded
+		return DecodeTransaction(data)
 	}
-	s := rlp.NewStream(bytes.NewReader(data), uint64(len(data)))
-	return DecodeTransaction(s)
 }
 
 func MarshalTransactionsBinary(txs Transactions) ([][]byte, error) {
@@ -212,8 +223,7 @@ func DecodeTransactions(txs [][]byte) ([]Transaction, error) {
 	result := make([]Transaction, len(txs))
 	var err error
 	for i := range txs {
-		s := rlp.NewStream(bytes.NewReader(txs[i]), uint64(len(txs[i])))
-		result[i], err = DecodeTransaction(s)
+		result[i], err = UnmarshalTransactionFromBinary(txs[i])
 		if err != nil {
 			return nil, err
 		}

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -17,7 +17,6 @@
 package types
 
 import (
-	"bytes"
 	"math/big"
 	"testing"
 
@@ -25,7 +24,6 @@ import (
 
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/crypto"
-	"github.com/ledgerwatch/erigon/rlp"
 	. "github.com/protolambda/ztyp/view"
 )
 
@@ -118,7 +116,7 @@ func TestEIP155SigningVitalik(t *testing.T) {
 	} {
 		signer := LatestSignerForChainID(big.NewInt(1))
 
-		tx, err := DecodeTransaction(rlp.NewStream(bytes.NewReader(common.Hex2Bytes(test.txRlp)), 0))
+		tx, err := DecodeTransaction(common.Hex2Bytes(test.txRlp))
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -101,7 +101,7 @@ var (
 
 func TestDecodeEmptyInput(t *testing.T) {
 	input := []byte{}
-	_, err := DecodeTransaction(rlp.NewStream(bytes.NewReader(input), 0))
+	_, err := DecodeTransaction(input)
 	if !errors.Is(err, io.EOF) {
 		t.Fatal("wrong error:", err)
 	}
@@ -109,7 +109,7 @@ func TestDecodeEmptyInput(t *testing.T) {
 
 func TestDecodeEmptyTypedTx(t *testing.T) {
 	input := []byte{0x80}
-	_, err := DecodeTransaction(rlp.NewStream(bytes.NewReader(input), 0))
+	_, err := DecodeTransaction(input)
 	if !errors.Is(err, rlp.EOL) {
 		t.Fatal("wrong error:", err)
 	}
@@ -263,9 +263,9 @@ func TestEIP1559TransactionEncode(t *testing.T) {
 		have := buf.Bytes()
 		want := common.FromHex("02f864010301018261a894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544c001a0c9519f4f2b30335884581971573fadf60c6204f59a911df35ee8a540456b2660a032f1e8e2c5dd761f9e4f88f41c8310aeaba26a8bfcdacfedfa12ec3862d37521")
 		if !bytes.Equal(have, want) {
-			t.Errorf("encoded RLP mismatch, got %x", have)
+			t.Errorf("encoded RLP mismatch, want %x got %x", want, have)
 		}
-		_, err := DecodeTransaction(rlp.NewStream(bytes.NewReader(buf.Bytes()), 0))
+		_, err := DecodeTransaction(buf.Bytes())
 		if err != nil {
 			t.Fatalf("decode error: %v", err)
 		}
@@ -274,7 +274,7 @@ func TestEIP1559TransactionEncode(t *testing.T) {
 }
 
 func decodeTx(data []byte) (Transaction, error) {
-	return DecodeTransaction(rlp.NewStream(bytes.NewReader(data), 0))
+	return DecodeTransaction(data)
 }
 
 func defaultTestKey() (*ecdsa.PrivateKey, common.Address) {

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -231,7 +231,7 @@ func (tp *TransactionsPacket) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx types.Transaction
-	for tx, err = types.DecodeTransaction(s); err == nil; tx, err = types.DecodeTransaction(s) {
+	for tx, err = types.DecodeRLPTransaction(s); err == nil; tx, err = types.DecodeRLPTransaction(s) {
 		*tp = append(*tp, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {
@@ -527,7 +527,7 @@ func (bb *BlockBody) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx types.Transaction
-	for tx, err = types.DecodeTransaction(s); err == nil; tx, err = types.DecodeTransaction(s) {
+	for tx, err = types.DecodeRLPTransaction(s); err == nil; tx, err = types.DecodeRLPTransaction(s) {
 		bb.Transactions = append(bb.Transactions, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {
@@ -800,7 +800,7 @@ func (ptp *PooledTransactionsPacket) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx types.Transaction
-	for tx, err = types.DecodeTransaction(s); err == nil; tx, err = types.DecodeTransaction(s) {
+	for tx, err = types.DecodeRLPTransaction(s); err == nil; tx, err = types.DecodeRLPTransaction(s) {
 		*ptp = append(*ptp, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {
@@ -897,7 +897,7 @@ func (ptp66 *PooledTransactionsPacket66) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	var tx types.Transaction
-	for tx, err = types.DecodeTransaction(s); err == nil; tx, err = types.DecodeTransaction(s) {
+	for tx, err = types.DecodeRLPTransaction(s); err == nil; tx, err = types.DecodeRLPTransaction(s) {
 		ptp66.PooledTransactionsPacket = append(ptp66.PooledTransactionsPacket, tx)
 	}
 	if !errors.Is(err, rlp.EOL) {

--- a/eth/protocols/eth/protocol_test.go
+++ b/eth/protocols/eth/protocol_test.go
@@ -151,7 +151,7 @@ func TestEth66Messages(t *testing.T) {
 		} {
 			var tx types.Transaction
 			rlpdata := common.FromHex(hexrlp)
-			tx, err1 := types.DecodeTransaction(rlp.NewStream(bytes.NewReader(rlpdata), 0))
+			tx, err1 := types.DecodeTransaction(rlpdata)
 			if err1 != nil {
 				t.Fatal(err1)
 			}

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -1,7 +1,6 @@
 package stagedsync
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -19,7 +18,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/txpool"
 	types2 "github.com/ledgerwatch/erigon-lib/types"
 
-	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/turbo/services"
 
 	"github.com/ledgerwatch/erigon/common"
@@ -256,13 +254,8 @@ func getNextTransactions(
 	}
 
 	var txs []types.Transaction //nolint:prealloc
-	reader := bytes.NewReader([]byte{})
-	stream := new(rlp.Stream)
 	for i := range txSlots.Txs {
-		reader.Reset(txSlots.Txs[i])
-		stream.Reset(reader, uint64(len(txSlots.Txs[i])))
-
-		transaction, err := types.DecodeTransaction(stream)
+		transaction, err := types.DecodeTransaction(txSlots.Txs[i])
 		if err == io.EOF {
 			continue
 		}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -17,7 +17,6 @@
 package tracers
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/json"
@@ -38,7 +37,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/vm/evmtypes"
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/params"
-	"github.com/ledgerwatch/erigon/rlp"
 	"github.com/ledgerwatch/erigon/tests"
 	"github.com/stretchr/testify/require"
 
@@ -234,7 +232,7 @@ func TestCallTracer(t *testing.T) {
 				t.Fatalf("failed to parse testcase: %v", err)
 			}
 			// Configure a blockchain with the given prestate
-			txn, err := types.DecodeTransaction(rlp.NewStream(bytes.NewReader(common.FromHex(test.Input)), 0))
+			txn, err := types.DecodeTransaction(common.FromHex(test.Input))
 			if err != nil {
 				t.Fatalf("failed to parse testcase input: %v", err)
 			}

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -17,7 +17,6 @@
 package tests
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -29,7 +28,6 @@ import (
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/params"
-	"github.com/ledgerwatch/erigon/rlp"
 )
 
 // TransactionTest checks RLP decoding and sender derivation of transactions.
@@ -60,7 +58,7 @@ type ttFork struct {
 
 func (tt *TransactionTest) Run(chainID *big.Int) error {
 	validateTx := func(rlpData hexutil.Bytes, signer types.Signer, rules *params.Rules) (*common.Address, *common.Hash, uint64, error) {
-		tx, err := types.DecodeTransaction(rlp.NewStream(bytes.NewReader(rlpData), 0))
+		tx, err := types.DecodeTransaction(rlpData)
 		if err != nil {
 			return nil, nil, 0, err
 		}

--- a/turbo/rpchelper/filters.go
+++ b/turbo/rpchelper/filters.go
@@ -568,8 +568,7 @@ func (ff *Filters) OnNewTx(reply *txpool.OnAddReply) {
 		if len(rlpTx) == 0 {
 			continue
 		}
-		s := rlp.NewStream(bytes.NewReader(rlpTx), uint64(len(rlpTx)))
-		txs[i], decodeErr = types.DecodeTransaction(s)
+		txs[i], decodeErr = types.DecodeTransaction(rlpTx)
 		if decodeErr != nil {
 			// ignoring what we can't unmarshal
 			log.Warn("OnNewTx rpc filters, unprocessable payload", "err", decodeErr, "data", hex.EncodeToString(rlpTx))

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -606,8 +606,6 @@ func (back *BlockReaderWithSnapshots) txsFromSnapshot(baseTxnID uint64, txsAmoun
 	txnOffset := txsSeg.IdxTxnHash.OrdinalLookup(baseTxnID - txsSeg.IdxTxnHash.BaseDataID())
 	gg := txsSeg.Seg.MakeGetter()
 	gg.Reset(txnOffset)
-	reader := bytes.NewReader(buf)
-	stream := rlp.NewStream(reader, 0)
 	for i := uint32(0); i < txsAmount; i++ {
 		if !gg.HasNext() {
 			return nil, nil, nil
@@ -618,9 +616,7 @@ func (back *BlockReaderWithSnapshots) txsFromSnapshot(baseTxnID uint64, txsAmoun
 		}
 		senders[i].SetBytes(buf[1 : 1+20])
 		txRlp := buf[1+20:]
-		reader.Reset(txRlp)
-		stream.Reset(reader, 0)
-		txs[i], err = types.DecodeTransaction(stream)
+		txs[i], err = types.DecodeTransaction(txRlp)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -640,7 +636,7 @@ func (back *BlockReaderWithSnapshots) txnByID(txnID uint64, sn *TxnSegment, buf 
 	buf, _ = gg.Next(buf[:0])
 	sender, txnRlp := buf[1:1+20], buf[1+20:]
 
-	txn, err = types.DecodeTransaction(rlp.NewStream(bytes.NewReader(txnRlp), uint64(len(txnRlp))))
+	txn, err = types.DecodeTransaction(txnRlp)
 	if err != nil {
 		return
 	}
@@ -668,7 +664,7 @@ func (back *BlockReaderWithSnapshots) txnByHash(txnHash common.Hash, segments []
 		senderByte, txnRlp := buf[1:1+20], buf[1+20:]
 		sender := *(*common.Address)(senderByte)
 
-		txn, err = types.DecodeTransaction(rlp.NewStream(bytes.NewReader(txnRlp), uint64(len(txnRlp))))
+		txn, err = types.DecodeTransaction(txnRlp)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
DecodeTransaction() previously took an RLP stream implying it was for RLP encoded transactions, but through somewhat of a hack was able to decode both RLP and canonical (which are "not quite rlp") encoded transactions. This hack no longer works with Blob type txs because of how they require the newer style SSZ decoding of the tx within the envelope.

This PR replaces the above with two new tx decoding functions to deal with this issue:

DecodeTransaction(data []byte)  :  this one can handle either RLP or canonical transaction encodings by "peeking" at the first byte to see which encoding type it is and delegating appropriately.

DecodeRLPTransaction(s rlp.Stream) : This one can only handle truely RLP encoded transactions, hence the change in the function name.
