### PR TITLE
fix issues with tx (encoding) size computations

### DIFF
--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -103,7 +103,6 @@ func (tx *AccessListTx) Size() common.StorageSize {
 		return size.(common.StorageSize)
 	}
 	c := tx.EncodingSize()
-	c++ // TxType
 	tx.size.Store(common.StorageSize(c))
 	return common.StorageSize(c)
 }


### PR DESCRIPTION
Fixes:
- blob tx computation was inappropriately adding in size prefix
- access list tx Size() computation was adding in type byte that was already being accounted for

+ added test case to detect regressions
