### PR TITLE
Make better use of tx interface

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -968,15 +968,7 @@ func (bb Body) payloadSize() (payloadSize int, txsLen, unclesLen, withdrawalsLen
 	payloadSize++
 	for _, tx := range bb.Transactions {
 		txsLen++
-		var txLen int
-		switch t := tx.(type) {
-		case *LegacyTx:
-			txLen = t.EncodingSize()
-		case *AccessListTx:
-			txLen = t.EncodingSize()
-		case *DynamicFeeTransaction:
-			txLen = t.EncodingSize()
-		}
+		txLen := int(tx.Size())
 		if txLen >= 56 {
 			txsLen += bitsToBytes(bits.Len(uint(txLen)))
 		}
@@ -1034,19 +1026,8 @@ func (bb Body) EncodeRLP(w io.Writer) error {
 		return err
 	}
 	for _, tx := range bb.Transactions {
-		switch t := tx.(type) {
-		case *LegacyTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *AccessListTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *DynamicFeeTransaction:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
+		if err := tx.EncodeRLP(w); err != nil {
+			return err
 		}
 	}
 	// encode Uncles
@@ -1336,19 +1317,7 @@ func (bb Block) payloadSize() (payloadSize int, txsLen, unclesLen, withdrawalsLe
 	payloadSize++
 	for _, tx := range bb.transactions {
 		txsLen++
-		var txLen int
-		switch t := tx.(type) {
-		case *LegacyTx:
-			txLen = t.EncodingSize()
-		case *AccessListTx:
-			txLen = t.EncodingSize()
-		case *DynamicFeeTransaction:
-			txLen = t.EncodingSize()
-		case *StarknetTransaction:
-			txLen = t.EncodingSize()
-		case *SignedBlobTx:
-			txLen = t.EncodingSize()
-		}
+		txLen := int(tx.Size())
 		if txLen >= 56 {
 			txsLen += bitsToBytes(bits.Len(uint(txLen)))
 		}
@@ -1416,27 +1385,8 @@ func (bb Block) EncodeRLP(w io.Writer) error {
 		return err
 	}
 	for _, tx := range bb.transactions {
-		switch t := tx.(type) {
-		case *LegacyTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *AccessListTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *DynamicFeeTransaction:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *StarknetTransaction:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *SignedBlobTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
+		if err := tx.EncodeRLP(w); err != nil {
+			return err
 		}
 	}
 	// encode Uncles

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -80,6 +80,7 @@ type Transaction interface {
 	Protected() bool
 	RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.Int)
 	MarshalBinary(w io.Writer) error
+	EncodeRLP(w io.Writer) error
 	// Sender returns the address derived from the signature (V, R, S) using secp256k1
 	// elliptic curve and an error if it failed deriving or upon an incorrect
 	// signature.

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -637,29 +637,8 @@ func encodeDecodeRLPAndCheckSize(tx Transaction) (Transaction, error) {
 	var buf bytes.Buffer
 	var err error
 
-	switch t := tx.(type) {
-	case *LegacyTx:
-		if err := t.EncodeRLP(&buf); err != nil {
-			return nil, err
-		}
-	case *AccessListTx:
-		if err := t.EncodeRLP(&buf); err != nil {
-			return nil, err
-		}
-	case *DynamicFeeTransaction:
-		if err := t.EncodeRLP(&buf); err != nil {
-			return nil, err
-		}
-	case *SignedBlobTx:
-		if err := t.EncodeRLP(&buf); err != nil {
-			return nil, err
-		}
-	case *BlobTxWrapper:
-		if err := t.EncodeRLP(&buf); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unknown tx type: %v", t)
+	if err := tx.EncodeRLP(&buf); err != nil {
+		return nil, err
 	}
 
 	// Confirm tx.Size() computes the right value

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -183,15 +183,7 @@ func (tp TransactionsPacket) EncodeRLP(w io.Writer) error {
 	var txsLen int
 	for _, tx := range tp {
 		txsLen++
-		var txLen int
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			txLen = t.EncodingSize()
-		case *types.AccessListTx:
-			txLen = t.EncodingSize()
-		case *types.DynamicFeeTransaction:
-			txLen = t.EncodingSize()
-		}
+		txLen := int(tx.Size())
 		if txLen >= 56 {
 			txsLen += (bits.Len(uint(txLen)) + 7) / 8
 		}
@@ -207,19 +199,8 @@ func (tp TransactionsPacket) EncodeRLP(w io.Writer) error {
 		return err
 	}
 	for _, tx := range tp {
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.AccessListTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.DynamicFeeTransaction:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
+		if err := tx.EncodeRLP(w); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -447,15 +428,7 @@ func (bb BlockBody) EncodeRLP(w io.Writer) error {
 	var txsLen int
 	for _, tx := range bb.Transactions {
 		txsLen++
-		var txLen int
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			txLen = t.EncodingSize()
-		case *types.AccessListTx:
-			txLen = t.EncodingSize()
-		case *types.DynamicFeeTransaction:
-			txLen = t.EncodingSize()
-		}
+		txLen := int(tx.Size())
 		if txLen >= 56 {
 			txsLen += (bits.Len(uint(txLen)) + 7) / 8
 		}
@@ -490,19 +463,8 @@ func (bb BlockBody) EncodeRLP(w io.Writer) error {
 		return err
 	}
 	for _, tx := range bb.Transactions {
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.AccessListTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.DynamicFeeTransaction:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
+		if err := tx.EncodeRLP(w); err != nil {
+			return err
 		}
 	}
 	// encode Uncles
@@ -786,15 +748,7 @@ func (ptp PooledTransactionsPacket) EncodeRLP(w io.Writer) error {
 	var txsLen int
 	for _, tx := range ptp {
 		txsLen++
-		var txLen int
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			txLen = t.EncodingSize()
-		case *types.AccessListTx:
-			txLen = t.EncodingSize()
-		case *types.DynamicFeeTransaction:
-			txLen = t.EncodingSize()
-		}
+		txLen := int(tx.Size())
 		if txLen >= 56 {
 			txsLen += (bits.Len(uint(txLen)) + 7) / 8
 		}
@@ -810,19 +764,8 @@ func (ptp PooledTransactionsPacket) EncodeRLP(w io.Writer) error {
 		return err
 	}
 	for _, tx := range ptp {
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.AccessListTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.DynamicFeeTransaction:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
+		if err := tx.EncodeRLP(w); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -860,15 +803,7 @@ func (ptp66 PooledTransactionsPacket66) EncodeRLP(w io.Writer) error {
 	var txsLen int
 	for _, tx := range ptp66.PooledTransactionsPacket {
 		txsLen++
-		var txLen int
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			txLen = t.EncodingSize()
-		case *types.AccessListTx:
-			txLen = t.EncodingSize()
-		case *types.DynamicFeeTransaction:
-			txLen = t.EncodingSize()
-		}
+		txLen := int(tx.Size())
 		if txLen >= 56 {
 			txsLen += (bits.Len(uint(txLen)) + 7) / 8
 		}
@@ -901,19 +836,8 @@ func (ptp66 PooledTransactionsPacket66) EncodeRLP(w io.Writer) error {
 		return err
 	}
 	for _, tx := range ptp66.PooledTransactionsPacket {
-		switch t := tx.(type) {
-		case *types.LegacyTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.AccessListTx:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
-		case *types.DynamicFeeTransaction:
-			if err := t.EncodeRLP(w); err != nil {
-				return err
-			}
+		if err := tx.EncodeRLP(w); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
- Add EncodeRLP to the interface, remove associated switch statements

- Change use of EncodingSize() to Size() now that they are equivalent, and remove associated switch statements