### PR TITLE
make dataGasUsed and dataGasPrice receipt fields derived

### DIFF
--- a/cmd/rpcdaemon/commands/erigon_receipts.go
+++ b/cmd/rpcdaemon/commands/erigon_receipts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math/big"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/ledgerwatch/erigon-lib/common"
@@ -391,10 +392,18 @@ func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonic
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
+	var edg *big.Int
+	if blockNum > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, blockNum-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	result := make([]map[string]interface{}, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
-		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true))
+		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, edg))
 	}
 
 	if chainConfig.Bor != nil {
@@ -405,7 +414,7 @@ func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonic
 				return nil, err
 			}
 			if borReceipt != nil {
-				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false))
+				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false, edg))
 			}
 		}
 	}

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ledgerwatch/erigon/common/hexutil"
 	"github.com/ledgerwatch/erigon/consensus"
+	"github.com/ledgerwatch/erigon/consensus/misc"
 	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/state"
@@ -64,6 +65,7 @@ func (api *BaseAPI) getReceipts(ctx context.Context, tx kv.Tx, chainConfig *chai
 	}
 	header := block.Header()
 	excessDataGas := header.ParentExcessDataGas(getHeader)
+
 	for i, txn := range block.Transactions() {
 		ibs.Prepare(txn.Hash(), block.Hash(), i)
 		receipt, _, err := core.ApplyTransaction(chainConfig, core.GetHashFn(header, getHeader), engine, nil, gp, ibs, noopWriter, header, txn, usedGas, vm.Config{}, excessDataGas)
@@ -646,6 +648,15 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 
+	var edg *big.Int
+	if n := block.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
+
 	if txn == nil {
 		borReceipt, err := rawdb.ReadBorReceipt(tx, block.Hash(), blockNum, receipts)
 		if err != nil {
@@ -654,14 +665,14 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		if borReceipt == nil {
 			return nil, nil
 		}
-		return marshalReceipt(borReceipt, borTx, cc, block.HeaderNoCopy(), txnHash, false), nil
+		return marshalReceipt(borReceipt, borTx, cc, block.HeaderNoCopy(), txnHash, false, edg), nil
 	}
 
 	if len(receipts) <= int(txnIndex) {
 		return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txnIndex), blockNum)
 	}
 
-	return marshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], cc, block.HeaderNoCopy(), txnHash, true), nil
+	return marshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], cc, block.HeaderNoCopy(), txnHash, true, edg), nil
 }
 
 // GetBlockReceipts - receipts for individual block
@@ -693,9 +704,17 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 	result := make([]map[string]interface{}, 0, len(receipts))
+	var edg *big.Int
+	if n := block.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
-		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true))
+		result = append(result, marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, edg))
 	}
 
 	if chainConfig.Bor != nil {
@@ -706,7 +725,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 				return nil, err
 			}
 			if borReceipt != nil {
-				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false))
+				result = append(result, marshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false, edg))
 			}
 		}
 	}
@@ -714,7 +733,7 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, number rpc.BlockNumber
 	return result, nil
 }
 
-func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *chain.Config, header *types.Header, txnHash common.Hash, signed bool) map[string]interface{} {
+func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *chain.Config, header *types.Header, txnHash common.Hash, signed bool, excessDataGas *big.Int) map[string]interface{} {
 	var chainId *big.Int
 	switch t := txn.(type) {
 	case *types.LegacyTx:
@@ -747,10 +766,6 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 		"logs":              receipt.Logs,
 		"logsBloom":         types.CreateBloom(types.Receipts{receipt}),
 	}
-	if receipt.DataGasUsed > 0 {
-		fields["dataGasUsed"] = hexutil.Uint64(receipt.DataGasUsed)
-		fields["dataGasPrice"] = hexutil.Uint64(receipt.DataGasPrice.Uint64())
-	}
 	if !chainConfig.IsLondon(header.Number.Uint64()) {
 		fields["effectiveGasPrice"] = hexutil.Uint64(txn.GetPrice().Uint64())
 	} else {
@@ -766,6 +781,16 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
 	if receipt.ContractAddress != (common.Address{}) {
 		fields["contractAddress"] = receipt.ContractAddress
+	}
+	// Set derived blob related fields
+	numBlobs := len(txn.GetDataHashes())
+	if numBlobs > 0 {
+		if excessDataGas == nil {
+			log.Warn("excess data gas not set when trying to marshal blob tx")
+		} else {
+			fields["dataGasPrice"] = misc.GetDataGasPrice(excessDataGas)
+			fields["dataGasUsed"] = misc.GetDataGasUsed(numBlobs)
+		}
 	}
 	return fields
 }

--- a/cmd/rpcdaemon/commands/graphql_api.go
+++ b/cmd/rpcdaemon/commands/graphql_api.go
@@ -76,11 +76,19 @@ func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
+	var edg *big.Int
+	if n := block.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	result := make([]map[string]interface{}, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := block.Transactions()[receipt.TransactionIndex]
 
-		transaction := marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true)
+		transaction := marshalReceipt(receipt, txn, chainConfig, block.HeaderNoCopy(), txn.Hash(), true, edg)
 		transaction["nonce"] = txn.GetNonce()
 		transaction["value"] = txn.GetValue()
 		transaction["data"] = txn.GetData()

--- a/cmd/rpcdaemon/commands/otterscan_api.go
+++ b/cmd/rpcdaemon/commands/otterscan_api.go
@@ -287,6 +287,7 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 	receipts := make([]map[string]interface{}, 0, pageSize)
 	resultCount := uint16(0)
 
+	var excessDataGas *big.Int
 	for txNumsIter.HasNext() {
 		txNum, blockNum, txIndex, isFinalTxn, blockNumChanged, err := txNumsIter.Next()
 		if err != nil {
@@ -306,6 +307,13 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 			}
 			blockHash = header.Hash()
 			exec.changeBlock(header)
+			if blockNum > 0 {
+				if parentHeader, err := api._blockReader.Header(ctx, tx, header.ParentHash, blockNum-1); err != nil {
+					return nil, err
+				} else {
+					excessDataGas = parentHeader.ExcessDataGas
+				}
+			}
 		}
 
 		//fmt.Printf("txNum=%d, blockNum=%d, txIndex=%d, maxTxNumInBlock=%d,mixTxNumInBlock=%d\n", txNum, blockNum, txIndex, maxTxNumInBlock, minTxNumInBlock)
@@ -327,7 +335,7 @@ func (api *OtterscanAPIImpl) searchTransactionsBeforeV3(tx kv.TemporalTx, ctx co
 			TransactionIndex: uint(txIndex),
 			BlockNumber:      header.Number, BlockHash: blockHash, Logs: rawLogs,
 		}
-		mReceipt := marshalReceipt(receipt, txn, chainConfig, header, txn.Hash(), true)
+		mReceipt := marshalReceipt(receipt, txn, chainConfig, header, txn.Hash(), true, excessDataGas)
 		mReceipt["timestamp"] = header.Time
 		receipts = append(receipts, mReceipt)
 
@@ -577,10 +585,19 @@ func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rp
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %v", err)
 	}
+
+	var edg *big.Int
+	if n := b.Number().Uint64(); n > 0 {
+		if parentHeader, err := api._blockReader.HeaderByNumber(ctx, tx, n-1); err != nil {
+			return nil, err
+		} else {
+			edg = parentHeader.ExcessDataGas
+		}
+	}
 	result := make([]map[string]interface{}, 0, len(receipts))
 	for _, receipt := range receipts {
 		txn := b.Transactions()[receipt.TransactionIndex]
-		marshalledRcpt := marshalReceipt(receipt, txn, chainConfig, b.HeaderNoCopy(), txn.Hash(), true)
+		marshalledRcpt := marshalReceipt(receipt, txn, chainConfig, b.HeaderNoCopy(), txn.Hash(), true, edg)
 		marshalledRcpt["logs"] = nil
 		marshalledRcpt["logsBloom"] = nil
 		result = append(result, marshalledRcpt)

--- a/cmd/rpcdaemon/commands/otterscan_search_trace.go
+++ b/cmd/rpcdaemon/commands/otterscan_search_trace.go
@@ -97,7 +97,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.Tx, ctx context.Context, blockNu
 
 		if tracer.Found {
 			rpcTx := newRPCTransaction(tx, block.Hash(), blockNum, uint64(idx), block.BaseFee())
-			mReceipt := marshalReceipt(blockReceipts[idx], tx, chainConfig, block.HeaderNoCopy(), tx.Hash(), true)
+			mReceipt := marshalReceipt(blockReceipts[idx], tx, chainConfig, block.HeaderNoCopy(), tx.Hash(), true, excessDataGas)
 			mReceipt["timestamp"] = block.Time()
 			rpcTxs = append(rpcTxs, rpcTx)
 			receipts = append(receipts, mReceipt)

--- a/consensus/misc/eip4844.go
+++ b/consensus/misc/eip4844.go
@@ -78,3 +78,7 @@ func VerifyEip4844Header(config *chain.Config, parent, header *types.Header) err
 func GetDataGasPrice(excessDataGas *big.Int) *big.Int {
 	return FakeExponential(big.NewInt(params.MinDataGasPrice), excessDataGas, big.NewInt(params.DataGasPriceUpdateFraction))
 }
+
+func GetDataGasUsed(numBlobs int) uint64 {
+	return uint64(numBlobs) * params.DataGasPerBlob
+}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -23,7 +23,6 @@ import (
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 
 	"github.com/ledgerwatch/erigon/consensus"
-	"github.com/ledgerwatch/erigon/consensus/misc"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/core/vm"
@@ -82,10 +81,6 @@ func applyTransaction(config *chain.Config, engine consensus.EngineReader, gp *G
 		}
 		receipt.TxHash = tx.Hash()
 		receipt.GasUsed = result.UsedGas
-		if result.UsedDataGas > 0 {
-			receipt.DataGasUsed = result.UsedDataGas
-			receipt.DataGasPrice = misc.GetDataGasPrice(excessDataGas)
-		}
 
 		// if the transaction created a contract, store the creation address in the receipt.
 		if msg.To() == nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -491,5 +491,5 @@ func (st *StateTransition) gasUsed() uint64 {
 }
 
 func (st *StateTransition) dataGasUsed() uint64 {
-	return uint64(len(st.msg.DataHashes())) * params.DataGasPerBlob
+	return misc.GetDataGasUsed(len(st.msg.DataHashes()))
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -63,8 +63,6 @@ type Receipt struct {
 	TxHash          libcommon.Hash    `json:"transactionHash" gencodec:"required" codec:"-"`
 	ContractAddress libcommon.Address `json:"contractAddress" codec:"-"`
 	GasUsed         uint64            `json:"gasUsed" gencodec:"required" codec:"-"`
-	DataGasUsed     uint64            `json:"dataGasUsed,omitempty" codec:"-"`
-	DataGasPrice    *big.Int          `json:"dataGasPrice,omitempty" codec:"-"`
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.


### PR DESCRIPTION
dataGasUsed and dataGasPrice need not be persisted in the receipt structure and should instead be derived on the fly by the get_receipt request handlers