### PR TITLE
adding data_gas in missed places & cosmetic changes

### DIFF
--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/node/nodecfg"
+	"github.com/ledgerwatch/erigon/params"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
 	"github.com/ledgerwatch/erigon/turbo/services"
 )
@@ -488,7 +489,7 @@ func (b *blockProcessor) applyBlock(
 
 	header := block.Header()
 	b.vmConfig.Debug = true
-	gp := new(core.GasPool).AddGas(block.GasLimit())
+	gp := new(core.GasPool).AddGas(block.GasLimit()).AddDataGas(params.MaxDataGasPerBlock)
 	usedGas := new(uint64)
 	var receipts types.Receipts
 	rules := b.chainConfig.Rules(block.NumberU64(), block.Time())

--- a/cmd/rpcdaemon/commands/eth_receipts.go
+++ b/cmd/rpcdaemon/commands/eth_receipts.go
@@ -517,7 +517,7 @@ func (e *intraBlockExec) execTx(txNum uint64, txIndex int, txn types.Transaction
 	txHash := txn.Hash()
 	e.ibs.Reset()
 	e.ibs.Prepare(txHash, e.blockHash, txIndex)
-	gp := new(core.GasPool).AddGas(txn.GetGas())
+	gp := new(core.GasPool).AddGas(txn.GetGas()).AddDataGas(txn.GetDataGas())
 	msg, err := txn.AsMessage(*e.signer, e.header.BaseFee, e.rules)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/state/commands/erigon4.go
+++ b/cmd/state/commands/erigon4.go
@@ -382,7 +382,7 @@ func processBlock23(startTxNum uint64, trace bool, txNumStart uint64, rw *StateR
 
 	header := block.Header()
 	vmConfig.Debug = true
-	gp := new(core.GasPool).AddGas(block.GasLimit())
+	gp := new(core.GasPool).AddGas(block.GasLimit()).AddDataGas(params.MaxDataGasPerBlock)
 	usedGas := new(uint64)
 	var receipts types.Receipts
 	rules := chainConfig.Rules(block.NumberU64(), block.Time())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -105,7 +105,7 @@ func ExecuteBlockEphemerally(
 		}
 	}
 	if !vmConfig.ReadOnly {
-		if err := InitializeBlockExecution(engine, chainReader, block.Header(), block.Transactions(), block.Uncles(), chainConfig, ibs, nil); err != nil {
+		if err := InitializeBlockExecution(engine, chainReader, block.Header(), block.Transactions(), block.Uncles(), chainConfig, ibs, excessDataGas); err != nil {
 			return nil, err
 		}
 	}
@@ -166,7 +166,7 @@ func ExecuteBlockEphemerally(
 	}
 	if !vmConfig.ReadOnly {
 		txs := block.Transactions()
-		if _, _, _, err := FinalizeBlockExecution(engine, stateReader, block.Header(), txs, block.Uncles(), stateWriter, chainConfig, ibs, receipts, block.Withdrawals(), chainReader, false, nil); err != nil {
+		if _, _, _, err := FinalizeBlockExecution(engine, stateReader, block.Header(), txs, block.Uncles(), stateWriter, chainConfig, ibs, receipts, block.Withdrawals(), chainReader, false, excessDataGas); err != nil {
 			return nil, err
 		}
 	}
@@ -216,7 +216,7 @@ func ExecuteBlockEphemerallyBor(
 		excessDataGas = ph.ExcessDataGas
 	}
 	if !vmConfig.ReadOnly {
-		if err := InitializeBlockExecution(engine, chainReader, block.Header(), block.Transactions(), block.Uncles(), chainConfig, ibs, nil); err != nil {
+		if err := InitializeBlockExecution(engine, chainReader, block.Header(), block.Transactions(), block.Uncles(), chainConfig, ibs, excessDataGas); err != nil {
 			return nil, err
 		}
 	}
@@ -277,7 +277,7 @@ func ExecuteBlockEphemerallyBor(
 	}
 	if !vmConfig.ReadOnly {
 		txs := block.Transactions()
-		if _, _, _, err := FinalizeBlockExecution(engine, stateReader, block.Header(), txs, block.Uncles(), stateWriter, chainConfig, ibs, receipts, block.Withdrawals(), chainReader, false, nil); err != nil {
+		if _, _, _, err := FinalizeBlockExecution(engine, stateReader, block.Header(), txs, block.Uncles(), stateWriter, chainConfig, ibs, receipts, block.Withdrawals(), chainReader, false, excessDataGas); err != nil {
 			return nil, err
 		}
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1218,14 +1218,6 @@ func CopyHeader(h *Header) *Header {
 		cpy.AuRaSeal = make([]byte, len(h.AuRaSeal))
 		copy(cpy.AuRaSeal, h.AuRaSeal)
 	}
-	if h.WithdrawalsHash != nil {
-		cpy.WithdrawalsHash = new(libcommon.Hash)
-		cpy.WithdrawalsHash.SetBytes(h.WithdrawalsHash.Bytes())
-	}
-	if h.ExcessDataGas != nil {
-		cpy.ExcessDataGas = new(big.Int)
-		cpy.ExcessDataGas.Set(h.ExcessDataGas)
-	}
 	return &cpy
 }
 

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -42,7 +42,7 @@ type txJSON struct {
 	BlobVersionedHashes []libcommon.Hash `json:"blobVersionedHashes,omitempty"`
 	// Blob wrapper fields:
 	Blobs       Blobs     `json:"blobs,omitempty"`
-	Commitments BlobKzgs  `json:commitments",omitempty"`
+	Commitments BlobKzgs  `json:"commitments,omitempty"`
 	Proofs      KZGProofs `json:"proofs,omitempty"`
 
 	// Only used for encoding:

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -23,12 +23,12 @@ import (
 	"math/big"
 
 	"github.com/holiman/uint256"
-
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/secp256k1"
+
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/crypto"
-	"github.com/ledgerwatch/secp256k1"
 )
 
 var ErrInvalidChainId = errors.New("invalid chain id for signer")
@@ -255,7 +255,6 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, tx Transaction) (
 		// id, add 27 to become equivalent to unprotected Homestead signatures.
 		V.Add(t.Signature.GetV(), u256.Num27)
 		R, S = t.Signature.GetR(), t.Signature.GetS()
-
 	default:
 		return libcommon.Address{}, ErrTxTypeNotSupported
 	}

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -112,7 +112,7 @@ func ComputeTxEnv(ctx context.Context, engine consensus.EngineReader, block *typ
 		}
 		vmenv.Reset(TxContext, statedb)
 		// Not yet the searched for transaction, execute on top of the current state
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(txn.GetGas()), true /* refunds */, false /* gasBailout */); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(txn.GetGas()).AddDataGas(txn.GetDataGas()), true /* refunds */, false /* gasBailout */); err != nil {
 			return nil, evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, nil, fmt.Errorf("transaction %x failed: %w", txn.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state
@@ -202,7 +202,7 @@ func TraceTx(
 		callmsg := prepareCallMessage(message)
 		result, err = statefull.ApplyBorMessage(*vmenv, callmsg)
 	} else {
-		result, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), refunds, false /* gasBailout */)
+		result, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()).AddDataGas(message.DataGas()), refunds, false /* gasBailout */)
 	}
 
 	if err != nil {


### PR DESCRIPTION
I found some places where `gaspool` may require `data_gas` and they are missing. Although, some of them may left without `data_gas` intentionally.  Fixed couple of places that probably appeared after merge with upstream. For example, `CopyHeader()` function has 2 if statements that were called earlier. `excessDataGas` added to function calls that expects them.