### PR TITLE
refactoring DecodeTransaction

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -979,7 +979,7 @@ func scanTxs(chaindata string) error {
 			return err
 		}
 		var tr types.Transaction
-		if tr, err = types.DecodeTransaction(v); err != nil {
+		if tr, err = types.DecodeTransaction(v, false); err != nil {
 			return err
 		}
 		if _, ok := trTypes[tr.Type()]; !ok {

--- a/cmd/rpcdaemon/commands/eth_txs.go
+++ b/cmd/rpcdaemon/commands/eth_txs.go
@@ -98,7 +98,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Has
 		return nil, err
 	}
 	if len(reply.RlpTxs[0]) > 0 {
-		txn, err := types2.DecodeTransaction(reply.RlpTxs[0])
+		txn, err := types2.DecodeTransaction(reply.RlpTxs[0], false)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rpcdaemon/commands/send_transaction.go
+++ b/cmd/rpcdaemon/commands/send_transaction.go
@@ -20,7 +20,7 @@ import (
 
 // SendRawTransaction implements eth_sendRawTransaction. Creates new message call transaction or a contract creation for previously-signed transactions.
 func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutility.Bytes) (common.Hash, error) {
-	txn, err := types.DecodeWrappedTransaction(encodedTx)
+	txn, err := types.DecodeTransaction(encodedTx, true)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/cmd/rpcdaemon/commands/txpool_api.go
+++ b/cmd/rpcdaemon/commands/txpool_api.go
@@ -51,7 +51,7 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 	baseFee := make(map[libcommon.Address][]types.Transaction, 8)
 	queued := make(map[libcommon.Address][]types.Transaction, 8)
 	for i := range reply.Txs {
-		txn, err := types.DecodeTransaction(reply.Txs[i].RlpTx)
+		txn, err := types.DecodeTransaction(reply.Txs[i].RlpTx, false)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/sentry/sentry/broadcast.go
+++ b/cmd/sentry/sentry/broadcast.go
@@ -71,7 +71,7 @@ func (cs *MultiClient) BroadcastNewBlock(ctx context.Context, header *types.Head
 	txs := make([]types.Transaction, len(body.Transactions))
 	for i, tx := range body.Transactions {
 		var err error
-		if txs[i], err = types.DecodeTransaction(tx); err != nil {
+		if txs[i], err = types.DecodeTransaction(tx, false); err != nil {
 			log.Error("broadcastNewBlock", "err", err)
 			return
 		}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -404,7 +404,7 @@ func CanonicalTxnByID(db kv.Getter, id uint64, blockHash libcommon.Hash, transac
 	if len(v) == 0 {
 		return nil, nil
 	}
-	txn, err := types.DecodeTransaction(v)
+	txn, err := types.DecodeTransaction(v, false)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func CanonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]type
 
 	if err := db.ForAmount(kv.EthTx, txIdKey, amount, func(k, v []byte) error {
 		var decodeErr error
-		if txs[i], decodeErr = types.UnmarshalTransactionFromBinary(v); decodeErr != nil {
+		if txs[i], decodeErr = types.DecodeTransaction(v, false); decodeErr != nil {
 			return decodeErr
 		}
 		i++
@@ -445,7 +445,7 @@ func NonCanonicalTransactions(db kv.Getter, baseTxId uint64, amount uint32) ([]t
 
 	if err := db.ForAmount(kv.NonCanonicalTxs, txIdKey, amount, func(k, v []byte) error {
 		var decodeErr error
-		if txs[i], decodeErr = types.DecodeTransaction(v); decodeErr != nil {
+		if txs[i], decodeErr = types.DecodeTransaction(v, false); decodeErr != nil {
 			return decodeErr
 		}
 		i++

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -118,7 +118,7 @@ func TestEIP155SigningVitalik(t *testing.T) {
 	} {
 		signer := LatestSignerForChainID(big.NewInt(1))
 
-		tx, err := DecodeTransaction(common.Hex2Bytes(test.txRlp))
+		tx, err := DecodeTransaction(common.Hex2Bytes(test.txRlp), false)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -107,7 +107,7 @@ var (
 
 func TestDecodeEmptyInput(t *testing.T) {
 	input := []byte{}
-	_, err := DecodeTransaction(input)
+	_, err := DecodeTransaction(input, false)
 	if !errors.Is(err, io.EOF) {
 		t.Fatal("wrong error:", err)
 	}
@@ -115,7 +115,7 @@ func TestDecodeEmptyInput(t *testing.T) {
 
 func TestDecodeEmptyTypedTx(t *testing.T) {
 	input := []byte{0x80}
-	_, err := DecodeTransaction(input)
+	_, err := DecodeTransaction(input, false)
 	if !errors.Is(err, rlp.EOL) {
 		t.Fatal("wrong error:", err)
 	}
@@ -271,7 +271,7 @@ func TestEIP1559TransactionEncode(t *testing.T) {
 		if !bytes.Equal(have, want) {
 			t.Errorf("encoded RLP mismatch, want %x got %x", want, have)
 		}
-		_, err := DecodeTransaction(buf.Bytes())
+		_, err := DecodeTransaction(buf.Bytes(), false)
 		if err != nil {
 			t.Fatalf("decode error: %v", err)
 		}
@@ -280,7 +280,7 @@ func TestEIP1559TransactionEncode(t *testing.T) {
 }
 
 func decodeTx(data []byte) (Transaction, error) {
-	return DecodeTransaction(data)
+	return DecodeTransaction(data, false)
 }
 
 func defaultTestKey() (*ecdsa.PrivateKey, libcommon.Address) {
@@ -607,7 +607,7 @@ func TestUnsupportedTxType(t *testing.T) {
 	// Change the first byte to emulate a non-supported tx type
 	b := buf.Bytes()
 	b[0] = 0x0F
-	_, err = UnmarshalTransactionFromBinary(b)
+	_, err = DecodeTransaction(b, false)
 	if err != ErrTxTypeNotSupported {
 		t.Fatalf("expected ErrTxTypeNotSupported, got: %v", err)
 	}
@@ -633,7 +633,7 @@ func encodeDecodeBinary(tx Transaction) (Transaction, error) {
 	}
 
 	var parsedTx Transaction
-	if parsedTx, err = UnmarshalTransactionFromBinary(buf.Bytes()); err != nil {
+	if parsedTx, err = DecodeTransaction(buf.Bytes(), false); err != nil {
 		return nil, fmt.Errorf("rlp decoding failed: %w", err)
 	}
 	return parsedTx, nil

--- a/eth/protocols/eth/protocol_test.go
+++ b/eth/protocols/eth/protocol_test.go
@@ -153,7 +153,7 @@ func TestEth66Messages(t *testing.T) {
 		} {
 			var tx types.Transaction
 			rlpdata := common.FromHex(hexrlp)
-			tx, err1 := types.DecodeTransaction(rlpdata)
+			tx, err1 := types.DecodeTransaction(rlpdata, false)
 			if err1 != nil {
 				t.Fatal(err1)
 			}

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -219,7 +219,7 @@ func getNextTransactions(
 
 	var txs []types.Transaction //nolint:prealloc
 	for i := range txSlots.Txs {
-		transaction, err := types.DecodeWrappedTransaction(txSlots.Txs[i])
+		transaction, err := types.DecodeTransaction(txSlots.Txs[i], true)
 		if err == io.EOF {
 			continue
 		}

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -126,7 +126,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			} else if err := json.Unmarshal(blob, test); err != nil {
 				t.Fatalf("failed to parse testcase: %v", err)
 			}
-			tx, err := types.UnmarshalTransactionFromBinary(common.FromHex(test.Input))
+			tx, err := types.DecodeTransaction(common.FromHex(test.Input), false)
 			if err != nil {
 				t.Fatalf("failed to parse testcase input: %v", err)
 			}
@@ -229,7 +229,7 @@ func BenchmarkTracers(b *testing.B) {
 
 func benchTracer(b *testing.B, tracerName string, test *callTracerTest) {
 	// Configure a blockchain with the given prestate
-	tx, err := types.DecodeTransaction(common.FromHex(test.Input))
+	tx, err := types.DecodeTransaction(common.FromHex(test.Input), false)
 	if err != nil {
 		b.Fatalf("failed to parse testcase input: %v", err)
 	}

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -90,7 +90,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			} else if err := json.Unmarshal(blob, test); err != nil {
 				t.Fatalf("failed to parse testcase: %v", err)
 			}
-			tx, err := types.UnmarshalTransactionFromBinary(common.FromHex(test.Input))
+			tx, err := types.DecodeTransaction(common.FromHex(test.Input), false)
 			if err != nil {
 				t.Fatalf("failed to parse testcase input: %v", err)
 			}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -210,7 +210,7 @@ func (t *StateTest) RunNoVerify(tx kv.RwTx, subtest StateSubtest, vmconfig vm.Co
 		return nil, libcommon.Hash{}, err
 	}
 	if len(post.Tx) != 0 {
-		txn, err := types.UnmarshalTransactionFromBinary(post.Tx)
+		txn, err := types.DecodeTransaction(post.Tx, false)
 		if err != nil {
 			return nil, libcommon.Hash{}, err
 		}

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -60,7 +60,7 @@ type ttFork struct {
 
 func (tt *TransactionTest) Run(chainID *big.Int) error {
 	validateTx := func(rlpData hexutility.Bytes, signer types.Signer, rules *chain.Rules) (*libcommon.Address, *libcommon.Hash, uint64, error) {
-		tx, err := types.DecodeTransaction(rlpData)
+		tx, err := types.DecodeTransaction(rlpData, false)
 		if err != nil {
 			return nil, nil, 0, err
 		}

--- a/turbo/rpchelper/filters.go
+++ b/turbo/rpchelper/filters.go
@@ -526,7 +526,7 @@ func (ff *Filters) OnNewTx(reply *txpool.OnAddReply) {
 		if len(rlpTx) == 0 {
 			continue
 		}
-		txs[i], decodeErr = types.DecodeWrappedTransaction(rlpTx)
+		txs[i], decodeErr = types.DecodeTransaction(rlpTx, true)
 		if decodeErr != nil {
 			// ignoring what we can't unmarshal
 			log.Warn("OnNewTx rpc filters, unprocessable payload", "err", decodeErr, "data", hex.EncodeToString(rlpTx))

--- a/turbo/snapshotsync/block_reader.go
+++ b/turbo/snapshotsync/block_reader.go
@@ -537,7 +537,7 @@ func (back *BlockReaderWithSnapshots) txsFromSnapshot(baseTxnID uint64, txsAmoun
 		}
 		senders[i].SetBytes(buf[1 : 1+20])
 		txRlp := buf[1+20:]
-		txs[i], err = types.DecodeTransaction(txRlp)
+		txs[i], err = types.DecodeTransaction(txRlp, false)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -557,7 +557,7 @@ func (back *BlockReaderWithSnapshots) txnByID(txnID uint64, sn *TxnSegment, buf 
 	buf, _ = gg.Next(buf[:0])
 	sender, txnRlp := buf[1:1+20], buf[1+20:]
 
-	txn, err = types.DecodeTransaction(txnRlp)
+	txn, err = types.DecodeTransaction(txnRlp, false)
 	if err != nil {
 		return
 	}
@@ -585,7 +585,7 @@ func (back *BlockReaderWithSnapshots) txnByHash(txnHash libcommon.Hash, segments
 		senderByte, txnRlp := buf[1:1+20], buf[1+20:]
 		sender := *(*libcommon.Address)(senderByte)
 
-		txn, err = types.DecodeTransaction(txnRlp)
+		txn, err = types.DecodeTransaction(txnRlp, false)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
It's just an idea to have a single function that decodes transactions instead of two almost identical functions. But now `DecodeTransaction` expects additional bool arg `isNetwork` indicating whether this is network encoded transaction. Also `unmarshalTransactionFromBinary` is no longer exported and strictly used only inside `DecodeTransaction` 